### PR TITLE
Safely removing symlink before creating again

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -260,6 +260,13 @@ class Manager {
         
         // need to rename binary?
         if (downloadCfg.bin) {
+          try {
+            var linkPath = path.join(unpackFolder, activeCli.bin);
+            fs.accessSync(linkPath, fs.R_OK);
+            fs.unlinkSync(linkPath);
+          }
+          catch (e) {}
+
           fs.symlinkSync(
             path.join(unpackFolder, downloadCfg.bin),
             path.join(unpackFolder, activeCli.bin),

--- a/src/index.js
+++ b/src/index.js
@@ -258,10 +258,10 @@ class Manager {
       return promise.then(() => {
         this._logger.debug(`Unzipped ${downloadFile} to ${unpackFolder}`);
         
+        const linkPath = path.join(unpackFolder, activeCli.bin);
         // need to rename binary?
         if (downloadCfg.bin) {
           try {
-            var linkPath = path.join(unpackFolder, activeCli.bin);
             fs.accessSync(linkPath, fs.R_OK);
             fs.unlinkSync(linkPath);
           }
@@ -269,7 +269,7 @@ class Manager {
 
           fs.symlinkSync(
             path.join(unpackFolder, downloadCfg.bin),
-            path.join(unpackFolder, activeCli.bin),
+            linkPath,
             'file'
           );
         }

--- a/src/index.js
+++ b/src/index.js
@@ -258,9 +258,9 @@ class Manager {
       return promise.then(() => {
         this._logger.debug(`Unzipped ${downloadFile} to ${unpackFolder}`);
         
-        const linkPath = path.join(unpackFolder, activeCli.bin);
         // need to rename binary?
         if (downloadCfg.bin) {
+          const linkPath = path.join(unpackFolder, activeCli.bin);
           try {
             fs.accessSync(linkPath, fs.R_OK);
             fs.unlinkSync(linkPath);


### PR DESCRIPTION
After having an old geth node and downloading a new one from the JSON config, the Client wasn't able to replace the existing symlink.

this change checks if the symlink exists and delete it prior creation.
