### PR TITLE
add optional md5 checksum

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethereum-client-binaries",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Download Ethereum client binaries for your OS",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -276,12 +276,12 @@ class Manager {
       // test checksum
       let value, algorithm, expectedHash;
 
-      if (value = _.get(downloadCfg, 'sha256')) {
-          expectedHash = value;
-          algorithm = 'sha256';
-      } else if (value = _.get(downloadCfg, 'md5')) {
+      if (value = _.get(downloadCfg, 'md5')) {
           expectedHash = value;
           algorithm = 'md5';
+      } else if (value = _.get(downloadCfg, 'sha256')) {
+          expectedHash = value;
+          algorithm = 'sha256';
       }
 
       if (algorithm) {

--- a/test/download.test.js
+++ b/test/download.test.js
@@ -21,9 +21,9 @@ test.after = function*() {
 
 test['no clients'] = function*() {
   let mgr = new this.Manager({
-    "clients": {} 
+    "clients": {}
   });
-  
+
   try {
     // mgr.logger = console;
     yield mgr.download('Maga');
@@ -43,9 +43,9 @@ test['client not supported on architecture'] = function*() {
         "args": ['test'],
         "output": [ "good:test" ]
       }
-    },               
+    },
   });
-  
+
   let mgr = new this.Manager({
     clients: {
       "Maga": {
@@ -57,10 +57,10 @@ test['client not supported on architecture'] = function*() {
       }
     }
   });
-  
+
   // mgr.logger = console;
   yield mgr.init();
-  
+
   try {
     yield mgr.download('Maga');
     throw -1;
@@ -80,9 +80,9 @@ test['client not supported on platform'] = function*() {
         "args": ['test'],
         "output": [ "good:test" ]
       }
-    },               
+    },
   });
-  
+
   let mgr = new this.Manager({
     clients: {
       "Maga": {
@@ -94,10 +94,10 @@ test['client not supported on platform'] = function*() {
       }
     }
   });
-  
+
   // mgr.logger = console;
   yield mgr.init();
-  
+
   try {
     yield mgr.download('Maga');
     throw -1;
@@ -116,9 +116,9 @@ test['download info not available'] = function*() {
         "args": ['test'],
         "output": [ "good:test" ]
       }
-    },               
+    },
   });
-  
+
   let mgr = new this.Manager({
     clients: {
       "Maga": {
@@ -130,10 +130,10 @@ test['download info not available'] = function*() {
       }
     }
   });
-  
+
   // mgr.logger = console;
   yield mgr.init();
-  
+
   try {
     yield mgr.download('Maga');
     throw -1;
@@ -155,9 +155,9 @@ test['download url not available'] = function*() {
         "args": ['test'],
         "output": [ "good:test" ]
       }
-    },               
+    },
   });
-  
+
   let mgr = new this.Manager({
     clients: {
       "Maga": {
@@ -169,10 +169,10 @@ test['download url not available'] = function*() {
       }
     }
   });
-  
+
   // mgr.logger = console;
   yield mgr.init();
-  
+
   try {
     yield mgr.download('Maga');
     throw -1;
@@ -193,9 +193,9 @@ test['download unpack command not available'] = function*() {
         "args": ['test'],
         "output": [ "good:test" ]
       }
-    },               
+    },
   });
-  
+
   let mgr = new this.Manager({
     clients: {
       "Maga": {
@@ -207,10 +207,10 @@ test['download unpack command not available'] = function*() {
       }
     }
   });
-  
+
   // mgr.logger = console;
   yield mgr.init();
-  
+
   try {
     yield mgr.download('Maga');
     throw -1;
@@ -233,9 +233,9 @@ test['download fails'] = function*() {
         "args": ['test'],
         "output": [ "good:test" ]
       }
-    },               
+    },
   });
-  
+
   let mgr = new this.Manager({
     clients: {
       "Maga": {
@@ -247,10 +247,10 @@ test['download fails'] = function*() {
       }
     }
   });
-  
+
   // mgr.logger = console;
   yield mgr.init();
-  
+
   try {
     yield mgr.download('Maga');
     throw -1;
@@ -277,9 +277,9 @@ test['unsupported archive type'] = function*() {
         "args": ['test'],
         "output": [ "good:test" ]
       }
-    },               
+    },
   });
-  
+
   let mgr = new this.Manager({
     clients: {
       "Maga2": {
@@ -291,10 +291,10 @@ test['unsupported archive type'] = function*() {
       }
     }
   });
-  
+
   // mgr.logger = console;
   yield mgr.init();
-  
+
   try {
     yield mgr.download('Maga2');
     throw -1;
@@ -305,7 +305,7 @@ test['unsupported archive type'] = function*() {
 
 
 
-test['hash mismatch'] = function*() {
+test['hash sha256 mismatch'] = function*() {
   const platforms = this.buildPlatformConfig(process.platform, process.arch, {
     download: {
       url: `${this.archiveTestHost}/maga2-good.zip`,
@@ -318,9 +318,9 @@ test['hash mismatch'] = function*() {
         "args": ['test'],
         "output": [ "good:test" ]
       }
-    },               
+    },
   });
-  
+
   let mgr = new this.Manager({
     clients: {
       "Maga2": {
@@ -332,10 +332,51 @@ test['hash mismatch'] = function*() {
       }
     }
   });
-  
+
   // mgr.logger = console;
   yield mgr.init();
-  
+
+  try {
+    yield mgr.download('Maga2');
+    throw -1;
+  } catch (err) {
+    err.message.should.contain(`Hash mismatch: blahblahblah`);
+  }
+};
+
+
+
+test['hash md5 mismatch'] = function*() {
+  const platforms = this.buildPlatformConfig(process.platform, process.arch, {
+    download: {
+      url: `${this.archiveTestHost}/maga2-good.zip`,
+      type: 'blah',
+      md5: 'blahblahblah'
+    },
+    "bin": "maga2",
+    "commands": {
+      "sanity": {
+        "args": ['test'],
+        "output": [ "good:test" ]
+      }
+    },
+  });
+
+  let mgr = new this.Manager({
+    clients: {
+      "Maga2": {
+        "homepage": "http://badgerbadgerbadger.com",
+        "version": "1.0.0",
+        "foo": "bar",
+        "versionNotes": "http://badgerbadgerbadger.com",
+        "platforms": platforms,
+      }
+    }
+  });
+
+  // mgr.logger = console;
+  yield mgr.init();
+
   try {
     yield mgr.download('Maga2');
     throw -1;
@@ -358,9 +399,9 @@ test['url regex mismatch'] = function*() {
         "args": ['test'],
         "output": [ "good:test" ]
       }
-    },               
+    },
   });
-  
+
   let mgr = new this.Manager({
     clients: {
       "Maga2": {
@@ -372,10 +413,10 @@ test['url regex mismatch'] = function*() {
       }
     }
   });
-  
+
   // mgr.logger = console;
   yield mgr.init();
-  
+
   try {
     yield mgr.download('Maga2', {
       urlRegex: /blahblah/i
@@ -401,9 +442,9 @@ test['custom unpack handler'] = {
           "args": ['test'],
           "output": [ "good:test" ]
         }
-      },               
+      },
     });
-    
+
     let mgr = new this.Manager({
       clients: {
         "Maga2": {
@@ -415,30 +456,30 @@ test['custom unpack handler'] = {
         }
       }
     });
-    
+
     // mgr.logger = console;
     yield mgr.init();
-    
+
     this.mgr = mgr;
   },
-  
+
   success: function*() {
     let spy = this.mocker.spy(() => Promise.resolve());
-    
+
     yield this.mgr.download('Maga2', {
       unpackHandler: spy
-    });    
-    
+    });
+
     spy.should.have.been.calledOnce;
     spy.getCall(0).args.length.should.eql(2);
   },
-  
+
   fail: function*() {
     try {
       yield this.mgr.download('Maga2', {
         unpackHandler: () => Promise.reject(new Error('foo!'))
-      });        
-      throw -1;      
+      });
+      throw -1;
     } catch (err) {
       err.message.should.contain(`foo!`);
     }
@@ -461,9 +502,9 @@ test['unpacks and verifies ok'] = function*() {
         "args": ['test'],
         "output": [ "good:test" ]
       }
-    },               
+    },
   });
-  
+
   let mgr = new this.Manager({
     clients: {
       "Maga2": {
@@ -475,21 +516,21 @@ test['unpacks and verifies ok'] = function*() {
       }
     }
   });
-  
+
   // mgr.logger = console;
   yield mgr.init();
-  
+
   let ret = yield mgr.download('Maga2', {
     urlRegex: /localhost/
   });
-  
+
   const downloadFolder = _get(ret, 'downloadFolder', '');
   _get(ret, 'downloadFile', '').should.eql(path.join(downloadFolder, `archive.zip`));
   _get(ret, 'unpackFolder', '').should.eql(path.join(downloadFolder, `unpacked`));
 
   _get(ret, 'client.state.available', '').should.be.true;
   _get(ret, 'client.activeCli.fullPath', '').should.eql(path.join(downloadFolder, `unpacked`, 'maga2'));
-  
+
   mgr.clients['Maga2'].should.eql(ret.client);
 };
 
@@ -507,9 +548,9 @@ test['unpacked but no binary found'] = function*() {
         "args": ['test'],
         "output": [ "good:test" ]
       }
-    },               
+    },
   });
-  
+
   let mgr = new this.Manager({
     clients: {
       "Maga2": {
@@ -521,12 +562,12 @@ test['unpacked but no binary found'] = function*() {
       }
     }
   });
-  
+
   // mgr.logger = console;
   yield mgr.init();
-  
+
   let ret = yield mgr.download('Maga2');
-  
+
   _get(ret, 'client.state.available', '').should.be.false;
   _get(ret, 'client.state.failReason', '').should.eql('notFound');
   _get(ret, 'client.activeCli.fullPath', '').should.eql('');
@@ -545,9 +586,9 @@ test['unpacked but sanity check failed'] = function*() {
         "args": ['test'],
         "output": [ "good:test" ]
       }
-    },               
+    },
   });
-  
+
   let mgr = new this.Manager({
     clients: {
       "Maga2": {
@@ -559,12 +600,12 @@ test['unpacked but sanity check failed'] = function*() {
       }
     }
   });
-  
+
   // mgr.logger = console;
   yield mgr.init();
-  
+
   let ret = yield mgr.download('Maga2');
-  
+
   _get(ret, 'client.state.available', '').should.be.false;
   _get(ret, 'client.state.failReason', '').should.eql('sanityCheckFail');
   _get(ret, 'client.activeCli.fullPath', '').should.eql('');
@@ -585,9 +626,9 @@ test['unpacked and set to required name'] = function*() {
         "args": ['test'],
         "output": [ "good:test" ]
       }
-    },               
+    },
   });
-  
+
   let mgr = new this.Manager({
     clients: {
       "Maga2": {
@@ -599,12 +640,12 @@ test['unpacked and set to required name'] = function*() {
       }
     }
   });
-  
+
   // mgr.logger = console;
   yield mgr.init();
-  
+
   let ret = yield mgr.download('Maga2');
-  
+
   _get(ret, 'client.state.available', '').should.be.true;
 };
 
@@ -634,16 +675,16 @@ test['unpacked updated version and copied over old version'] = function*(){
       }
     }
   };
-  
+
   let mgr = new this.Manager(buildMgrOpts(this, downloadOpts));
   // mgr.logger = console;
-  
+
   yield mgr.init();
-  
+
   let ret = yield mgr.download('Maga2');
 
   const downloadFolder = _get(ret, 'downloadFolder', '');
-  
+
   _get(ret, 'client.activeCli.fullPath', '').should.eql(path.join(downloadFolder, 'unpacked', 'maga3'));
 
   // Settings params for 2nd download
@@ -657,7 +698,7 @@ test['unpacked updated version and copied over old version'] = function*(){
   // mgr2.logger = console;
 
   yield mgr2.init();
-  
+
   let ret2 = yield mgr2.download('Maga2', {downloadFolder: path.join(downloadFolder, '..')});
 
   _get(ret2, 'client.activeCli.fullPath', '').should.eql(path.join(downloadFolder, 'unpacked', 'maga3'));
@@ -665,14 +706,14 @@ test['unpacked updated version and copied over old version'] = function*(){
   // check that maga3 === maga2-special
   const hash1 = md5File.sync(path.join(downloadFolder, 'unpacked', 'maga3'));
   const hash2 = md5File.sync(path.join(downloadFolder, 'unpacked', 'maga2-special'));
-  
+
   hash1.should.eql(hash2);
 }
 
 
 
 
-test['hash match'] = function*() {
+test['hash sha256 match'] = function*() {
   const platforms = this.buildPlatformConfig(process.platform, process.arch, {
     download: {
       url: `${this.archiveTestHost}/maga2-good.zip`,
@@ -685,7 +726,46 @@ test['hash match'] = function*() {
         "args": ['test'],
         "output": [ "good:test" ]
       }
-    },               
+    },
+  });
+
+  let mgr = new this.Manager({
+    clients: {
+      "Maga2": {
+        "homepage": "http://badgerbadgerbadger.com",
+        "version": "1.0.0",
+        "foo": "bar",
+        "versionNotes": "http://badgerbadgerbadger.com",
+        "platforms": platforms,
+      }
+    }
+  });
+
+  // mgr.logger = console;
+  yield mgr.init();
+
+  let ret = yield mgr.download('Maga2');
+
+  mgr.clients['Maga2'].should.eql(ret.client);
+};
+
+
+
+
+test['hash md5 match'] = function*() {
+  const platforms = this.buildPlatformConfig(process.platform, process.arch, {
+    download: {
+      url: `${this.archiveTestHost}/maga2-good.zip`,
+      type: 'zip',
+      md5: 'dff641865ffb9b44d53f1f9def74f2e6'
+    },
+    "bin": "maga2",
+    "commands": {
+      "sanity": {
+        "args": ['test'],
+        "output": [ "good:test" ]
+      }
+    },
   });
 
   let mgr = new this.Manager({


### PR DESCRIPTION
This PR adds the possibility to use md5 checksums for binary validation.
The code will only check using one hash-algorithm. Priority list is: md5, sha256, no checksum

TODO:
- [x] write tests