### PR TITLE
fix 'fs.access' ghost error, remove obsolete 'fs.unlink'

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -347,8 +347,7 @@ class Manager {
           let realPath = path.join(unpackFolder, downloadCfg.bin);
 
           try {
-            fs.accessSync(linkPath, fs.R_OK);
-            fs.unlinkSync(linkPath);
+            fs.accessSync(realPath, fs.R_OK);
           } catch (e) {
             this._logger.warn(e);
           }

--- a/src/index.js
+++ b/src/index.js
@@ -347,9 +347,11 @@ class Manager {
           let realPath = path.join(unpackFolder, downloadCfg.bin);
 
           try {
-            fs.accessSync(realPath, fs.R_OK);
+            fs.accessSync(linkPath, fs.R_OK);
+            fs.unlinkSync(linkPath);
           } catch (e) {
-            this._logger.warn(e);
+            if (e.code !== 'ENOENT')
+              this._logger.warn(e);
           }
 
           return copyFile(realPath, linkPath).then(() => linkPath)


### PR DESCRIPTION
Eventually this step could be removed completely.

Ram, please feel free to publish a new version after merging these two - or should alex do now?! :)