### PR TITLE
remove redundant debugging log lines

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -288,7 +288,7 @@ class Manager {
         return checksum(dInfo.downloadFile, algorithm)
           .then((hash) => {
             if (expectedHash !== hash) {
-              throw new Error(`Hash mismatch: ${expectedHash}`);
+              throw new Error(`Hash mismatch (using ${algorithm}): expected ${expectedHash}; got ${hash}`);
             }
             return dInfo;
           });

--- a/src/index.js
+++ b/src/index.js
@@ -287,9 +287,6 @@ class Manager {
       if (algorithm) {
         return checksum(dInfo.downloadFile, algorithm)
           .then((hash) => {
-              this._logger.error(algorithm)
-                  this._logger.error(hash)
-                      this._logger.error(expectedHash)
             if (expectedHash !== hash) {
               throw new Error(`Hash mismatch: ${expectedHash}`);
             }

--- a/test/download.test.js
+++ b/test/download.test.js
@@ -340,7 +340,7 @@ test['hash sha256 mismatch'] = function*() {
     yield mgr.download('Maga2');
     throw -1;
   } catch (err) {
-    err.message.should.contain(`Hash mismatch: blahblahblah`);
+    err.message.should.contain(`Hash mismatch (using sha256): expected blahblahblah; got e7781ccd95e2db9246dbe8c1deaf9238ab4428a713d08080689834fd68a25652`);
   }
 };
 
@@ -381,7 +381,7 @@ test['hash md5 mismatch'] = function*() {
     yield mgr.download('Maga2');
     throw -1;
   } catch (err) {
-    err.message.should.contain(`Hash mismatch: blahblahblah`);
+    err.message.should.contain(`Hash mismatch (using md5): expected blahblahblah; got dff641865ffb9b44d53f1f9def74f2e6`);
   }
 };
 


### PR DESCRIPTION
As those are remains of the checksum refactor; checksum-errors will still throw meaningful errors to the console.