### PR TITLE
Updating default config file

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1,79 +1,90 @@
 {
-  "clients": {
-    "Geth": {
-      "platforms": {
-        "linux": {
-          "x64": {
-            "download": {
-              "url": "https://bintray.com/artifact/download/karalabe/ethereum/geth-1.4.12-stable-421df86-linux-amd64.tar.bz2",
-              "type": "tar"
-            },
-            "bin": "geth",
-            "commands": {
-              "sanity": {
-                "args": ["version"],
-                "output": [ "Geth" ]
-              }                
+    "clients": {
+        "Geth": {
+            "version": "1.5.5",
+            "platforms": {
+                "linux": {
+                    "x64": {
+                        "download": {
+                            "url": "https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.5.5-ff07d548.tar.gz",
+                            "type": "tar",
+                            "sha256": "4f36d6df25c37eb33829407d8bf2cea209cc412b3443319e2430db18581c7c01",
+                            "bin": "geth-linux-amd64-1.5.5-ff07d548/geth"
+                        },
+                        "bin": "geth",
+                        "commands": {
+                            "sanity": {
+                                "args": ["version"],
+                                "output": [ "Geth", "1.5.5" ]
+                            }
+                        }
+                    },
+                    "ia32": {
+                        "download": {
+                            "url": "https://gethstore.blob.core.windows.net/builds/geth-linux-386-1.5.5-ff07d548.tar.gz",
+                            "type": "tar",
+                            "sha256": "6767651e4e5b34acaa6c53079d66a9047acb74e80fd25f570bf63da87d0ce863",
+                            "bin": "geth-linux-386-1.5.5-ff07d548/geth"
+                        },
+                        "bin": "geth",
+                        "commands": {
+                            "sanity": {
+                                "args": ["version"],
+                                "output": [ "Geth", "1.5.5" ]
+                            }
+                        }
+                    }
+                },
+                "mac": {
+                    "x64": {
+                        "download": {
+                            "url": "https://gethstore.blob.core.windows.net/builds/geth-darwin-amd64-1.5.5-ff07d548.tar.gz",
+                            "type": "tar",
+                            "sha256": "a5b3ae5b7e9d91a0ca42ca24b079631578cdccce036cc5b1f0035cd0d9706b53",
+                            "bin": "geth-darwin-amd64-1.5.5-ff07d548/geth"
+                        },
+                        "bin": "geth",
+                        "commands": {
+                            "sanity": {
+                                "args": ["version"],
+                                "output": [ "Geth", "1.5.5" ]
+                            }
+                        }
+                    }
+                },
+                "win": {
+                    "x64": {
+                        "download": {
+                            "url": "https://gethstore.blob.core.windows.net/mist/geth-windows-amd64-1.5.5-ff07d548-mist-fix.zip",
+                            "type": "zip",
+                            "sha256": "6b9e65ccac8a07535fbfd003662cdd4f69289f93947689c715d10c6486e703d7",
+                            "bin": "geth-windows-amd64-1.5.5-ff07d548\\geth.exe"
+                        },
+                        "bin": "geth.exe",
+                        "commands": {
+                            "sanity": {
+                                "args": ["version"],
+                                "output": [ "Geth", "1.5.5" ]
+                            }
+                        }
+                    },
+                    "ia32": {
+                        "download": {
+                            "url": "https://gethstore.blob.core.windows.net/mist/geth-windows-386-1.5.5-ff07d548-mist-fix.zip",
+                            "type": "zip",
+                            "sha256": "74ef8372ae7748c1016a8fcfe2d49574b52a2780913081cf0184fb197f26f01c",
+                            "bin": "geth-windows-386-1.5.5-ff07d548\\geth.exe"
+                        },
+                        "bin": "geth.exe",
+                        "commands": {
+                            "sanity": {
+                                "args": ["version"],
+                                "output": [ "Geth", "1.5.5" ]
+                            }
+                        }
+                    }
+                }
             }
-          },
-          "ia32": {
-            "download": {
-              "url": "https://bintray.com/artifact/download/karalabe/ethereum/geth-1.4.12-stable-421df86-linux-386.tar.bz2",
-              "type": "tar"
-            },
-            "bin": "geth",
-            "commands": {
-              "sanity": {
-                "args": ["version"],
-                "output": [ "Geth" ]
-              }                
-            }
-          }
-        },
-        "mac": {
-          "x64": {
-            "download": {
-              "url": "https://bintray.com/artifact/download/karalabe/ethereum/geth-1.4.12-stable-421df86-darwin-10.6-amd64.tar.bz2",
-              "type": "tar"
-            },
-            "bin": "geth",
-            "commands": {
-              "sanity": {
-                "args": ["version"],
-                "output": [ "Geth" ]
-              }                
-            }
-          }
-        },
-        "win": {
-          "x64": {
-            "download": {
-              "url": "https://github.com/ethereum/go-ethereum/releases/download/v1.4.11/Geth-Win64-20160818153642-1.4.11-fed692f.zip",
-              "type": "zip"
-            },
-            "bin": "geth.exe",
-            "commands": {
-              "sanity": {
-                "args": ["version"],
-                "output": [ "Geth" ]
-              }                
-            }
-          },
-          "ia32": {
-            "download": {
-              "url": "https://bintray.com/artifact/download/karalabe/ethereum/geth-1.4.12-stable-421df86-windows-4.0-386.exe.zip",
-              "type": "zip"
-            },
-            "bin": "geth.exe",
-            "commands": {
-              "sanity": {
-                "args": ["version"],
-                "output": [ "Geth" ]
-              }                
-            }
-          }            
         }
-      }
     }
-  }
 }


### PR DESCRIPTION
As we have more features added to ethereum client binaries, this PR updates the default config file with checksums and latest geth.