### PR TITLE
fix searching binary path

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -510,8 +510,7 @@ class Manager {
       if (process.platform === 'win32') {
           command = 'where';
       } else {
-          command = 'command';
-          args.push('-v');
+          command = 'which';
       }
       args.push(binName);
 


### PR DESCRIPTION
`command` can be found with execve in mac os but not in other linux os like ubuntu, debian.
This can be fixed by changing from `command` to `which`.

This check is not working in ubuntu so the mist-wallet forced to download the package.
<pre>
[pid 20322] execve("/usr/local/sbin/command", ["command", "-v", "geth"], [/* 67 vars */]) = -1 ENOENT (No such file or directory)
[pid 20322] execve("/usr/local/bin/command", ["command", "-v", "geth"], [/* 67 vars */]) = -1 ENOENT (No such file or directory)
[pid 20322] execve("/usr/sbin/command", ["command", "-v", "geth"], [/* 67 vars */]) = -1 ENOENT (No such file or directory)
[pid 20322] execve("/usr/bin/command", ["command", "-v", "geth"], [/* 67 vars */]) = -1 ENOENT (No such file or directory)
[pid 20322] execve("/sbin/command", ["command", "-v", "geth"], [/* 67 vars */]) = -1 ENOENT (No such file or directory)
[ERROR] ClientBinaryManager - Unable to resolve Geth executable: geth
[INFO] ClientBinaryManager - Download binary for Geth ...
[INFO] ClientBinaryManager - Downloading package from https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.5.5-ff07d548.tar.gz to 
</pre>