### PR TITLE
Updating node-unzip-2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ os: osx
 language: node_js
 
 node_js:
-  - "4"
   - "6"
+  - "8"
   
 script:
   - "npm run test-coverage"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lodash.values": "^4.3.0",
     "mkdirp": "^0.5.1",
     "tmp": "0.0.29",
-    "node-unzip-2": "^0.2.1"
+    "node-unzip-2": "glebdmitriew/node-unzip-2"
   },
   "devDependencies": {
     "bluebird": "^3.4.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethereum-client-binaries",
-  "version": "1.6.2",
+  "version": "1.6.4",
   "description": "Download Ethereum client binaries for your OS",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lodash.values": "^4.3.0",
     "mkdirp": "^0.5.1",
     "tmp": "0.0.29",
-    "node-unzip-2": "glebdmitriew/node-unzip-2"
+    "unzip": "github:glebdmitriew/node-unzip-2"
   },
   "devDependencies": {
     "bluebird": "^3.4.6",

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ const got = require('got'),
   path = require('path'),
   tmp = require('tmp'),
   mkdirp = require('mkdirp'),
-  unzip = require('node-unzip-2'),
+  unzip = require('unzip'),
   spawn = require('buffered-spawn');
 
 const _ = {


### PR DESCRIPTION
Pulling dependency from Github, as the library wasn't yet updated on npm. 

Once the maintainer does that, we can change to the updated npm version. See https://github.com/glebdmitriew/node-unzip-2/pull/21
